### PR TITLE
Glowing no longer overrides other EntityMetadata

### DIFF
--- a/src/main/java/com/sitrica/glowing/GlowingAPI.java
+++ b/src/main/java/com/sitrica/glowing/GlowingAPI.java
@@ -95,7 +95,10 @@ public class GlowingAPI implements Listener {
 					// The packet is already a glowing update.
 					if (existing == 0x40)
 						return;
-					sendGlowing(entity, player);
+					// Finally if packet does not contain glowing data, add it
+					if ((existing & (1 << 6)) == 0){
+						sendGlowing(entity, player);
+					}
 				}
 			}
 		});
@@ -175,14 +178,18 @@ public class GlowingAPI implements Listener {
 
 	/**
 	 * Sends the glowing packet not caring about overriding.
-	 * 
+	 *
 	 * @param entity The entity to apply glowing to.
 	 * @param receiver The player that sees the effects of glowing.
 	 */
 	private void sendGlowing(Entity entity, Player receiver) {
 		WrapperPlayServerEntityMetadata wrapper = new WrapperPlayServerEntityMetadata();
 		WrappedDataWatcher watcher = WrappedDataWatcher.getEntityWatcher(entity);
-		watcher.setObject(0, Registry.get(Byte.class), (byte) 0x40);
+
+		byte data = watcher.getByte(0);
+		data |= 1 << 6;
+
+		watcher.setObject(0, Registry.get(Byte.class), data);
 
 		wrapper.setMetadata(watcher.getWatchableObjects());
 		wrapper.setEntityID(entity.getEntityId());


### PR DESCRIPTION
- sendGlowing() now changes the 7th bit of the entitymetadata and leaves the other bits as they were instead of overriding the entire thing

- onPacketSending() now only runs sendGlowing() if the 7th bit is zero (and the player is suppose to be glowing)